### PR TITLE
remap /share calls

### DIFF
--- a/src/main/java/com/kryptnostic/kodex/v1/models/response/BasicResponse.java
+++ b/src/main/java/com/kryptnostic/kodex/v1/models/response/BasicResponse.java
@@ -1,14 +1,17 @@
 package com.kryptnostic.kodex.v1.models.response;
 
+import javax.annotation.concurrent.Immutable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.kryptnostic.kodex.v1.constants.Names;
 
 /**
  * Immutable basic response model for web services http://wiki.krypt.local/display/PS/Basic+Response+Model
- * 
+ *
  * @author sina
  */
+@Immutable
 public class BasicResponse<T> {
     protected final T       data;
     protected final int     status;

--- a/src/main/java/com/kryptnostic/sharing/v1/http/SharingApi.java
+++ b/src/main/java/com/kryptnostic/sharing/v1/http/SharingApi.java
@@ -21,6 +21,7 @@ import com.kryptnostic.storage.v1.models.EncryptedSearchObjectKey;
 public interface SharingApi {
     String SHARE       = "/share";
     String OBJECT      = "/object";
+    String REVOKE      = "/revoke";
     String KEYS        = "/keys";
     String OBJECT_KEYS = "/objectKeys";
 
@@ -30,10 +31,10 @@ public interface SharingApi {
     @POST( SHARE + OBJECT + "/{id}" )
     BasicResponse<String> removeIncomingShares( @Path( "id" ) String uuid );
 
-    @POST( SHARE + OBJECT )
+    @POST( SHARE + OBJECT + SHARE )
     BasicResponse<String> share( @Body SharingRequest request );
 
-    @DELETE( SHARE + OBJECT )
+    @POST( SHARE + OBJECT + REVOKE )
     BasicResponse<String> revokeAccess( @Body RevocationRequest request );
 
     @POST( SHARE + KEYS )


### PR DESCRIPTION
retrofit does not allow a body for DELETE requests
maps both /share and /unshare to POST requests and disambiguates the URLs