### PR TITLE
change the child id separator

### DIFF
--- a/src/main/java/com/kryptnostic/storage/v1/ObjectIds.java
+++ b/src/main/java/com/kryptnostic/storage/v1/ObjectIds.java
@@ -15,7 +15,7 @@ public final class ObjectIds {
 
     private ObjectIds() { /* not to be instantiated */ }
 
-    public static final String CHILD_OBJECT_SEPARATOR = ":";
+    public static final String CHILD_OBJECT_SEPARATOR = "~";
 
     public static String getChildObjectId(String objectId, int childIndex) {
         Validate.isTrue(StringUtils.isNotBlank(objectId));


### PR DESCRIPTION
Using ":" caused deserialization to fail in rethink
Use "~" which is not used in rethink mappers

(cherry picked from commit 89d96195a2032af9050af4db6c9fd93663ee4143)